### PR TITLE
Add a contract-callable `encTransfer` that accepts an `euint128`

### DIFF
--- a/packages/hardhat/contracts/FHERC20.sol
+++ b/packages/hardhat/contracts/FHERC20.sol
@@ -201,6 +201,8 @@ abstract contract FHERC20 is IFHERC20, IFHERC20Errors, Context, EIP712, Nonces {
     /**
      * @dev See {IERC20-transfer}.
      *
+     * Intended to be used as a EOA call with an encrypted input `InEuint128 inValue`.
+     *
      * Requirements:
      *
      * - `to` cannot be the zero address.
@@ -208,7 +210,22 @@ abstract contract FHERC20 is IFHERC20, IFHERC20Errors, Context, EIP712, Nonces {
      * - `inValue` must be a `InEuint128` to preserve confidentiality.
      */
     function encTransfer(address to, InEuint128 memory inValue) public virtual returns (euint128 transferred) {
-        euint128 value = FHE.asEuint128(inValue);
+        return encTransfer(to, FHE.asEuint128(inValue));
+    }
+
+    /**
+     * @dev See {IERC20-transfer}.
+     *
+     * Intended to be used as part of a contract call.
+     * Ensure that `value` is allowed to be used by using `FHE.allow` with this contracts address.
+     *
+     * Requirements:
+     *
+     * - `to` cannot be the zero address.
+     * - the caller must have a balance of at least `value`.
+     * - `value` must be a `euint128` to preserve confidentiality.
+     */
+    function encTransfer(address to, euint128 value) public virtual returns (euint128 transferred) {
         address owner = _msgSender();
         transferred = _transfer(owner, to, value);
     }

--- a/packages/hardhat/test/FHERC20.test.ts
+++ b/packages/hardhat/test/FHERC20.test.ts
@@ -240,7 +240,9 @@ describe("FHERC20", function () {
       await prepExpectFHERC20BalancesChange(XFHE, bob.address);
       await prepExpectFHERC20BalancesChange(XFHE, alice.address);
 
-      await expect(XFHE.connect(bob).encTransfer(alice.address, encTransferInput))
+      await expect(
+        XFHE.connect(bob)["encTransfer(address,(uint256,uint8,uint8,bytes))"](alice.address, encTransferInput),
+      )
         .to.emit(XFHE, "Transfer")
         .withArgs(bob.address, alice.address, await tick(XFHE));
 
@@ -267,10 +269,9 @@ describe("FHERC20", function () {
       const [encTransferInput] = await hre.cofhe.expectResultSuccess(encTransferResult);
 
       // encTransfer (reverts)
-      await expect(XFHE.connect(bob).encTransfer(ZeroAddress, encTransferInput)).to.be.revertedWithCustomError(
-        XFHE,
-        "ERC20InvalidReceiver",
-      );
+      await expect(
+        XFHE.connect(bob)["encTransfer(address,(uint256,uint8,uint8,bytes))"](ZeroAddress, encTransferInput),
+      ).to.be.revertedWithCustomError(XFHE, "ERC20InvalidReceiver");
     });
   });
 


### PR DESCRIPTION
Request from Felend, an oversight originally