### PR TITLE
Improve text visibility in dark mode

### DIFF
--- a/packages/nextjs/components/AddToken.tsx
+++ b/packages/nextjs/components/AddToken.tsx
@@ -151,7 +151,7 @@ export const PublicTokenDetails = ({
           <TokenIconSymbol publicToken={tokenDetails} className="text-primary-accent bg-button-hover p-1.5 pr-3" />
           <div className="flex flex-col flex-1 gap-2">
             <span className="text-primary font-semibold font-reddit-mono">{name}</span>
-            <div className="flex flex-row justify-between gap-4 text-sm text-gray-500">
+            <div className="flex flex-row justify-between gap-4 text-sm text-base-content/60 dark:text-white/70">
               <span>
                 Decimals: <span className="font-semibold font-reddit-mono">{decimals}</span>
               </span>
@@ -210,7 +210,7 @@ export const ConfidentialTokenDetails = ({
           {!requiresDeployment && (
             <div className="flex flex-col flex-1 gap-2">
               <span className="text-primary font-semibold font-reddit-mono">{name}</span>
-              <div className="flex flex-row justify-between gap-4 text-sm text-gray-500">
+              <div className="flex flex-row justify-between gap-4 text-sm text-base-content/60 dark:text-white/70">
                 <span>
                   Decimals: <span className="font-semibold font-reddit-mono">{decimals}</span>
                 </span>

--- a/packages/nextjs/components/SelectToken.tsx
+++ b/packages/nextjs/components/SelectToken.tsx
@@ -236,7 +236,7 @@ function TokenListItem({ tokenPair, onSelect }: { tokenPair: ConfidentialTokenPa
           </div>
           <div className="flex flex-col">
             <span className="text-primary font-semibold">{publicToken.symbol}</span>
-            <span className="text-sm text-gray-500">{getConfidentialSymbol(tokenPair)}</span>
+            <span className="text-sm text-base-content/60 dark:text-white/70">{getConfidentialSymbol(tokenPair)}</span>
           </div>
         </div>
         <div className="flex flex-col items-end">

--- a/packages/nextjs/components/TransactionHistory.tsx
+++ b/packages/nextjs/components/TransactionHistory.tsx
@@ -45,7 +45,7 @@ const TransactionItem = ({ tx }: { tx: RedactTransaction }) => {
           >
             {statusToString(tx.status)}
           </div>
-          <div className="text-xs text-gray-500">{formatDistanceToNow(tx.timestamp, { addSuffix: true })}</div>
+          <div className="text-xs text-base-content/60 dark:text-white/70">{formatDistanceToNow(tx.timestamp, { addSuffix: true })}</div>
         </div>
 
         <div className="flex flex-col justify-between items-stretch">
@@ -53,7 +53,7 @@ const TransactionItem = ({ tx }: { tx: RedactTransaction }) => {
             {formatTokenAmount(tx.tokenAmount, tx.tokenDecimals)} {tx.tokenSymbol}
           </div>
           <HashLink
-            className="text-xs text-gray-500"
+            className="text-xs text-base-content/60 dark:text-white/70"
             buttonSize={3}
             copyStrokeWidth={1.0}
             type="tx"
@@ -79,7 +79,7 @@ export const TransactionHistory = ({ pair }: TransactionHistoryProps) => {
   if (!transactions.length) {
     return (
       <div className="p-4 text-center">
-        <p className="text-gray-500">No transactions found</p>
+        <p className="text-base-content/60 dark:text-white/70">No transactions found</p>
       </div>
     );
   }


### PR DESCRIPTION
A dark mode contrast issue was identified where secondary text was difficult to read.

The fix involved replacing the `text-gray-500` Tailwind CSS class with `text-base-content/60 dark:text-white/70` across several components:

*   In `SelectToken.tsx`, the confidential token symbols (e.g., "eUSDC", "eEURC") were updated.
*   In `AddToken.tsx`, the token decimals and balance information text in `PublicTokenDetails` and `ConfidentialTokenDetails` components were adjusted.
*   In `TransactionHistory.tsx`, transaction timestamps, hash links, and the "No transactions found" message were updated.

This change ensures:
*   **Light Mode:** Text uses the theme's base content color with 60% opacity, maintaining visual hierarchy.
*   **Dark Mode:** Text is white with 70% opacity, providing clear contrast against dark backgrounds.

The new classes leverage the existing DaisyUI theme system, ensuring consistent and accessible text readability across both light and dark modes.