### PR TITLE
Fix visual issue while we relax

### DIFF
--- a/packages/nextjs/components/menu-pages/SendPage.tsx
+++ b/packages/nextjs/components/menu-pages/SendPage.tsx
@@ -89,6 +89,24 @@ const AmountInputRow = () => {
   const setToken = useSelectSendToken();
   const setSliderValue = useUpdateSendValueByPercent();
 
+  const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+    // If the input shows "0", select all text so typing replaces it entirely
+    if (e.target.value === "0") {
+      e.target.select();
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    // If user is typing and the current value is "0", replace it entirely
+    if ((inputValue === "0" || inputValue === "") && value.length > 1 && value.startsWith("0") && value[1] !== ".") {
+      // Remove the leading zero unless it's a decimal (like "0.5")
+      setInputValue(value.substring(1));
+    } else {
+      setInputValue(value);
+    }
+  };
+
   return (
     <div className="mb-5 w-full flex content-stretch rounded-2xl border border-[#3399FF] p-4">
       <div className="flex flex-col items-start flex-1">
@@ -97,7 +115,8 @@ const AmountInputRow = () => {
           type="number"
           min="0"
           value={inputValue === "" ? "0" : inputValue}
-          onChange={e => setInputValue(e.target.value)}
+          onChange={handleChange}
+          onFocus={handleFocus}
           className="w-30 text-lg text-primary-accent font-bold outline-none no-spinner"
         />
         {/* TODO: add fiat amount */}

--- a/packages/nextjs/services/store/sendStore.ts
+++ b/packages/nextjs/services/store/sendStore.ts
@@ -85,10 +85,11 @@ export const useUpdateSendValue = () => {
         // Disallow negative numbers
         if (value.startsWith("-")) return;
 
-        // If empty, treat as "0"
-        const sanitized = value === "" ? "0" : value;
+        // Store the actual input string (can be empty)
+        state.inputString = value;
 
-        state.inputString = sanitized;
+        // For calculations, treat empty as "0"
+        const sanitized = value === "" ? "0" : value;
 
         // Allow only numbers and optional single decimal point, no negatives
         if (/^\d*\.?\d*$/.test(sanitized)) {


### PR DESCRIPTION
The issue of an initial "0" not automatically deleting in the amount input field, potentially causing 10x errors, was addressed.

Changes were made in two files:

*   In `packages/nextjs/components/menu-pages/SendPage.tsx`:
    *   An `onFocus` handler was added to the `AmountInputRow`'s input. If the input value is "0" when focused, all text is automatically selected, allowing immediate replacement upon typing.
    *   The `onChange` handler was modified to remove leading zeros (e.g., "0123" becomes "123") unless it's a decimal (e.g., "0.5"). This ensures intuitive input behavior.

*   In `packages/nextjs/services/store/sendStore.ts`:
    *   The `useUpdateSendValue` function was updated. The raw input string, including an empty state, is now stored in `state.inputString`.
    *   The conversion of an empty string to "0" (`value === "" ? "0" : value`) is now applied only for internal calculations, separating display logic from the numerical value used in the store.

These changes ensure the input field behaves intuitively: "0" acts as a placeholder that is easily replaced, preventing accidental digit prepending and magnitude errors.