### PR TITLE
fix(ConfidentialETH): use safe `staticcall` in `_cappedDecimals` to avoid revert on non-standard WETH

### DIFF
--- a/packages/hardhat/contracts/ConfidentialETH.sol
+++ b/packages/hardhat/contracts/ConfidentialETH.sol
@@ -32,7 +32,12 @@ contract ConfidentialETH is FHERC20NativeWrapperUpgradeable, OwnableUpgradeable,
     }
 
     function _cappedDecimals(address token) private view returns (uint8) {
-        uint8 d = IERC20Metadata(token).decimals();
+        // Use a low-level staticcall so that non-standard WETH implementations
+        // that revert or omit decimals() do not brick initialization.
+        // Falls back to 18 (the ERC-20 default) on failure, matching the
+        // behaviour of ConfidentialERC20._cappedDecimals.
+        (bool ok, bytes memory data) = token.staticcall(abi.encodeCall(IERC20Metadata.decimals, ()));
+        uint8 d = (ok && data.length == 32) ? abi.decode(data, (uint8)) : 18;
         return d > 6 ? 6 : d;
     }
 


### PR DESCRIPTION
## Summary

`ConfidentialETH._cappedDecimals` calls `IERC20Metadata(token).decimals()` directly. If the WETH contract does not implement `decimals()` or reverts (e.g., a non-standard or incorrectly deployed WETH), the entire `ConfidentialETH.initialize` call reverts with no meaningful error.

## Inconsistency

The sibling contract `ConfidentialERC20` already handles this correctly with a safe staticcall + fallback:

```solidity
// ConfidentialERC20._cappedDecimals (safe ✓)
function _cappedDecimals(address token) private view returns (uint8) {
    (bool ok, bytes memory data) = token.staticcall(abi.encodeCall(IERC20Metadata.decimals, ()));
    uint8 d = (ok && data.length == 32) ? abi.decode(data, (uint8)) : 18;
    return d > 6 ? 6 : d;
}

// ConfidentialETH._cappedDecimals (unsafe ✗)
function _cappedDecimals(address token) private view returns (uint8) {
    uint8 d = IERC20Metadata(token).decimals();  // reverts on failure
    return d > 6 ? 6 : d;
}
```

## Impact

Since `ConfidentialETH` is deployed behind a UUPS proxy via `initialize`, if initialization reverts the proxy is permanently bricked — `_disableInitializers()` in the constructor means the implementation cannot be re-initialized, and a new proxy would need to be deployed. Deploying with a non-standard WETH or a network where WETH hasn't been fully set up yet would silently fail in a non-recoverable way.

## Fix

Apply the same safe staticcall pattern as `ConfidentialERC20._cappedDecimals`, falling back to 18 decimals on failure.