### PR TITLE
fix(RedactCore): reject zero address in `deployConfidentialERC20`

### DIFF
--- a/packages/hardhat/contracts/RedactCore.sol
+++ b/packages/hardhat/contracts/RedactCore.sol
@@ -37,6 +37,7 @@ contract RedactCore is Ownable2Step {
     error InvalidWETH();
     error InvalidEETH();
     error InvalidImplementation();
+    error InvalidERC20();
 
     constructor(
         IWETH wETH_,
@@ -92,6 +93,7 @@ contract RedactCore is Ownable2Step {
      * Reverts if a wrapper already exists or if `erc20` is WETH (use {eETH} instead).
      */
     function deployConfidentialERC20(IERC20 erc20) public returns (address) {
+        if (address(erc20) == address(0)) revert InvalidERC20();
         if (address(erc20) == address(wETH)) revert InvalidWETH();
         if (_confidentialERC20Map.contains(address(erc20))) revert AlreadyDeployed();
 


### PR DESCRIPTION
## Summary

`deployConfidentialERC20` is a **permissionless** factory function — anyone can call it. It currently checks only that the token is not WETH and has not already been deployed, but it does not check that `erc20 != address(0)`.

## Bug

```solidity
function deployConfidentialERC20(IERC20 erc20) public returns (address) {
    if (address(erc20) == address(wETH)) revert InvalidWETH();
    if (_confidentialERC20Map.contains(address(erc20))) revert AlreadyDeployed();
    // ↑ No zero-address check! address(0) passes both guards.

    bytes memory initData = abi.encodeCall(ConfidentialERC20.initialize, (erc20));
    ERC1967Proxy proxy = new ERC1967Proxy(confidentialERC20Implementation, initData);
    // ConfidentialERC20.initialize does not revert for address(0) —
    // IERC20Metadata(address(0)).name() would revert, but _isFHERC20(address(0))
    // catches that and returns false, so initialize proceeds.

    _confidentialERC20Map.set(address(erc20), address(proxy));
    // ← address(0) is now permanently registered in the EnumerableMap.
    ...
}
```

**Impact:**
- The `address(0)` slot in `_confidentialERC20Map` is permanently poisoned — it cannot be removed.
- `getConfidentialERC20(address(0))` returns a non-zero address, creating a potential false-positive in any code that uses zero-address as a sentinel.
- The `AlreadyDeployed` guard then prevents anyone from attempting to fix it with a second call.

## Fix

Add `if (address(erc20) == address(0)) revert InvalidERC20();` as the first check in the function.