### PR TITLE
fix(nextjs): parse the unshield amount in confidential decimals

### DIFF
--- a/packages/nextjs/services/store/encryptDecrypt.ts
+++ b/packages/nextjs/services/store/encryptDecrypt.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { useDecryptValue } from "./decrypted";
-import { useConfidentialTokenPair, useConfidentialTokenPairBalances } from "./tokenStore";
+import { ConfidentialTokenPair, useConfidentialTokenPair, useConfidentialTokenPairBalances } from "./tokenStore";
 import { FheTypes } from "@cofhe/sdk";
 import { Address, formatUnits, parseUnits } from "viem";
 import { useAccount, useChainId } from "wagmi";
@@ -28,6 +28,14 @@ export const useEncryptDecryptStore = create<EncryptDecryptStore>()(
     hasInteracted: false,
   })),
 );
+
+/**
+ * Decimals of the amount being entered. Encrypting (shield) moves the underlying token, so the
+ * amount is in public decimals. Decrypting (unshield) moves the confidential balance, which the
+ * FHERC20 denominates in its own (capped) decimals.
+ */
+const inputDecimals = (pair: ConfidentialTokenPair | undefined, isEncrypt: boolean) =>
+  isEncrypt ? (pair?.publicToken.decimals ?? 18) : (pair?.confidentialToken?.decimals ?? 6);
 
 // Actions
 
@@ -105,7 +113,7 @@ export const useUpdateEncryptDecryptValue = () => {
         // Allow only numbers and optional single decimal point, no negatives
         if (/^\d*\.?\d*$/.test(sanitized)) {
           try {
-            const amount = parseUnits(sanitized, pair.publicToken.decimals);
+            const amount = parseUnits(sanitized, inputDecimals(pair, state.isEncrypt));
             if (state.isEncrypt) {
               state.encryptValue = amount;
             } else {
@@ -134,11 +142,12 @@ export const useEncryptDecryptRawInputValue = () => {
 export const useEncryptDecryptInputValue = () => {
   const rawInputValue = useEncryptDecryptRawInputValue();
   const pair = useEncryptDecryptPair();
+  const isEncrypt = useEncryptDecryptIsEncrypt();
 
   return useMemo(() => {
     if (pair == null) return "";
-    return formatUnits(rawInputValue, pair.publicToken.decimals);
-  }, [pair, rawInputValue]);
+    return formatUnits(rawInputValue, inputDecimals(pair, isEncrypt));
+  }, [pair, isEncrypt, rawInputValue]);
 };
 
 export const useEncryptDecryptInputString = () => {
@@ -164,10 +173,7 @@ export const useUpdateEncryptDecryptValueByPercent = () => {
           state.decryptValue = amount;
         }
         // Update the input string with the formatted amount
-        const currentTokenDecimals = !state.isEncrypt
-          ? (pair?.confidentialToken?.decimals ?? 6)
-          : (pair?.publicToken.decimals ?? 18);
-        state.inputString = formatUnits(amount, currentTokenDecimals);
+        state.inputString = formatUnits(amount, inputDecimals(pair, state.isEncrypt));
       });
     },
     [pair, balances],


### PR DESCRIPTION
The unshield amount is parsed with the wrong decimals. `useUpdateEncryptDecryptValue` always does `parseUnits(sanitized, pair.publicToken.decimals)`, but in the decrypt direction that value goes straight into `unshield(from, to, uint64 amount)`, which takes the amount in the confidential token's own decimals, and the FHERC20 wrapper caps those at 6. The call site in `MainTokenSwapping` already passes `tokenDecimals: pair.confidentialToken.decimals` for that same value, so only the parse disagreed.

For the ETH pair (public 18, confidential 6) typing 1 gives 1e18 where the contract wants 1e6. You mostly can't get that far though, because `useEncryptDecryptValueError` compares the input against the decrypted confidential balance, which is in 6 decimals. Holding 1 eETH that comparison is 1000000000000000000 against 1000000, so anything you type comes back as insufficient balance. The percent buttons show the same split from the other end: they already store the right raw value, but `useEncryptDecryptInputValue` renders it with public decimals, so 50% of 1 eETH appears in the box as 0.0000000000005 instead of 0.5.

`useUpdateEncryptDecryptValueByPercent` was already choosing decimals by direction, so I lifted that expression into a small `inputDecimals(pair, isEncrypt)` helper and used it in all three places. Shield is untouched, `shield(to, uint256 amount)` really does take underlying units and that call site already passes `publicToken.decimals`.

Worth noting why this went unseen: the token list only ships USDC and EURC, both 6 decimals, so public and confidential coincide and nothing looks wrong. ETH is the pair that breaks and it has its own branch in the selector.

There is no test runner in `packages/nextjs`, so I could not add a test. `check-types` passes, `lint` reports no errors (the prettier warnings it prints are pre-existing, all in the generated `lib/abis.ts`), and `prettier --check` passes on the changed file.
